### PR TITLE
Change how Unmarshal works

### DIFF
--- a/osubool.go
+++ b/osubool.go
@@ -9,7 +9,7 @@ type OsuBool bool
 
 // UnmarshalJSON converts `"0"` to false and `"1"` to true.
 func (o *OsuBool) UnmarshalJSON(data []byte) error {
-	if string(data) == `"0"` {
+	if string(data) == `0` {
 		*o = false
 		return nil
 	}


### PR DESCRIPTION
Previously it will convert everything from the API to `true`, because `string(data)` is `0` or `1`, not `"0"` and `"1"`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thehowl/go-osuapi/1)
<!-- Reviewable:end -->
