### PR TITLE
Add CreatorID to get_beatmaps call

### DIFF
--- a/get_beatmaps.go
+++ b/get_beatmaps.go
@@ -50,6 +50,7 @@ type Beatmap struct {
 	Artist            string         `json:"artist"`
 	Title             string         `json:"title"`
 	Creator           string         `json:"creator"`
+	CreatorID         int            `json:"creator_id"`
 	BPM               float64        `json:"bpm,string"`
 	Source            string         `json:"source"`
 	Tags              string         `json:"tags"`


### PR DESCRIPTION
Currently missing, allowing creator ID in this lets u obtain other stuff that Creator itself cant such as the user's ava